### PR TITLE
Reduce forced reflow in UI scripts

### DIFF
--- a/js/benderEyes.js
+++ b/js/benderEyes.js
@@ -5,6 +5,7 @@ const observerOptions = {
 };
 
 let isEyeGroupVisibleMap = new Map();
+const eyeGroupMatrixMap = new Map();
 const observer = new IntersectionObserver((entries) => {
   entries.forEach(entry => {
     const eyeGroup = entry.target;
@@ -15,6 +16,21 @@ const observer = new IntersectionObserver((entries) => {
 document.querySelectorAll('.eyeGroup').forEach(eyeGroup => {
   observer.observe(eyeGroup);
   isEyeGroupVisibleMap.set(eyeGroup, true);
+  eyeGroupMatrixMap.set(eyeGroup, eyeGroup.getScreenCTM().inverse());
+});
+
+// Recalculate matrices on resize to keep positions accurate
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.eyeGroup').forEach(eyeGroup => {
+    eyeGroupMatrixMap.set(eyeGroup, eyeGroup.getScreenCTM().inverse());
+  });
+});
+
+// Track viewport size without triggering layout
+const mobileQuery = window.matchMedia('(max-width: 750px)');
+let isMobile = mobileQuery.matches;
+mobileQuery.addEventListener('change', e => {
+  isMobile = e.matches;
 });
 
 export function benderEyes(event) {
@@ -32,7 +48,8 @@ export function benderEyes(event) {
     const svgPoint = svgRoot.createSVGPoint();
     svgPoint.x = event.clientX;
     svgPoint.y = event.clientY;
-    const pointTransformed = svgPoint.matrixTransform(eyeGroup.getScreenCTM().inverse());
+    const ctm = eyeGroupMatrixMap.get(eyeGroup);
+    const pointTransformed = svgPoint.matrixTransform(ctm);
     const eyeCenterX = parseFloat(eye.getAttribute('cx'));
     const eyeCenterY = parseFloat(eye.getAttribute('cy'));
     const dx = pointTransformed.x - eyeCenterX;
@@ -44,7 +61,6 @@ export function benderEyes(event) {
     const targetY = eyeCenterY + distance * Math.sin(angle);
     const currentX = parseFloat(pupil.getAttribute('x')) + pupilSize || eyeCenterX;
     const currentY = parseFloat(pupil.getAttribute('y')) + pupilSize || eyeCenterY;
-    const isMobile = window.innerWidth <= 750;
     const lerpFactor = isMobile ? 0.5 : 0.1;
     const smoothX = currentX + (targetX - currentX) * lerpFactor;
     const smoothY = currentY + (targetY - currentY) * lerpFactor;

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   navbarEffects();
   switchMode();
   hamburguerMenu();
-  benderEyes({ clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 });
+  requestAnimationFrame(() => {
+    benderEyes({ clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 });
+  });
   initializeProjects();
   allWindowReload();
   initializeCertificates();

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,7 +1,9 @@
+const desktopQuery = window.matchMedia('(min-width: 1326px)');
+
 export function navbarEffects() {
   const navbar = document.getElementById('navb');
   let lastScrollPosition = 0;
-  let isDesktop = window.innerWidth >= 1326;
+  let isDesktop = desktopQuery.matches;
 
   function handleScroll() {
     const currentScrollPosition = window.scrollY;
@@ -16,7 +18,7 @@ export function navbarEffects() {
   }
 
   function checkViewportWidth() {
-    isDesktop = window.innerWidth >= 1326;
+    isDesktop = desktopQuery.matches;
 
     if (isDesktop) {
       window.addEventListener('scroll', handleScroll);
@@ -26,8 +28,9 @@ export function navbarEffects() {
     }
   }
   checkViewportWidth();
-  window.addEventListener('resize', checkViewportWidth);
+  desktopQuery.addEventListener('change', checkViewportWidth);
 }
+
 
 export function hamburguerMenu() {
   document.getElementById('hamburguer').addEventListener('click', function () {
@@ -76,7 +79,7 @@ export function smoothScrollWithOffset() {
           behavior: 'smooth'
         });
 
-        if (window.innerWidth < 1326) {
+        if (!desktopQuery.matches) {
           navbar.classList.remove('active');
         }
       }
@@ -88,7 +91,7 @@ export function hamburnavbarEffectsMobile() {
   const navbar = document.getElementById('navb');
   const hamburguerBtn = document.getElementById('hamburguer');
   let lastScrollPosition = 0;
-  let isDesktop = window.innerWidth >= 1326;
+  let isDesktop = desktopQuery.matches;
 
   function handleScroll() {
     const currentScrollPosition = window.scrollY;
@@ -107,7 +110,7 @@ export function hamburnavbarEffectsMobile() {
   }
 
   function checkViewportWidth() {
-    isDesktop = window.innerWidth >= 1326;
+    isDesktop = desktopQuery.matches;
 
     if (isDesktop) {
       window.addEventListener('scroll', handleScroll);
@@ -120,5 +123,5 @@ export function hamburnavbarEffectsMobile() {
   }
 
   checkViewportWidth();
-  window.addEventListener('resize', checkViewportWidth);
+  desktopQuery.addEventListener('change', checkViewportWidth);
 }

--- a/js/progressBar.js
+++ b/js/progressBar.js
@@ -31,8 +31,10 @@ export function setupProgressBar(containerElement, initialPercentage, type = 'sk
   let dragOffset = 0;
   const originalWidth = Math.max(minWidth, Math.min(maxWidth, parseFloat(initialPercentage)));
 
+  // Cache marker width to avoid repeated layout reads
+  const markerOffset = marker.offsetWidth / 2;
+
   function updateMarkerPosition(widthPercentage) {
-    const markerOffset = marker.offsetWidth / 2;
     marker.style.left = `calc(${widthPercentage}% - ${markerOffset}px)`;
   }
 
@@ -61,10 +63,14 @@ export function setupProgressBar(containerElement, initialPercentage, type = 'sk
 
   observer.observe(progressBar);
 
+  // Cache bounding rect to avoid forced reflow during drag
+  let progressBarRect = progressBar.getBoundingClientRect();
+
   function startDrag(e) {
     isDragging = true;
     progressFill.style.transition = 'none';
     marker.style.transition = 'none';
+    progressBarRect = progressBar.getBoundingClientRect();
     const clientX = e.clientX || e.touches?.[0]?.clientX;
     const markerRect = marker.getBoundingClientRect();
     dragOffset = clientX - (markerRect.left + markerRect.width / 2);
@@ -72,7 +78,7 @@ export function setupProgressBar(containerElement, initialPercentage, type = 'sk
 
   function drag(e) {
     if (!isDragging) return;
-    const rect = progressBar.getBoundingClientRect();
+    const rect = progressBarRect;
     const clientX = e.clientX || e.touches?.[0]?.clientX;
     let newWidth = ((clientX - dragOffset - rect.left) / rect.width) * 100;
     newWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
@@ -89,10 +95,15 @@ export function setupProgressBar(containerElement, initialPercentage, type = 'sk
     updateMarkerPosition(originalWidth);
   }
 
+  // Update cached rect on resize to keep values accurate
+  window.addEventListener('resize', () => {
+    progressBarRect = progressBar.getBoundingClientRect();
+  });
+
   marker.addEventListener('mousedown', startDrag);
   document.addEventListener('mousemove', drag);
   document.addEventListener('mouseup', endDrag);
   marker.addEventListener('touchstart', startDrag);
-  document.addEventListener('touchmove', drag);
+  document.addEventListener('touchmove', drag, { passive: false });
   document.addEventListener('touchend', endDrag);
 }

--- a/js/skills.js
+++ b/js/skills.js
@@ -40,8 +40,10 @@ function setupDisplayMode() {
     });
 }
 
+const scrollModeQuery = window.matchMedia('(max-width: 549px)');
+
 function handleResponsiveDisplay() {
-    if (window.innerWidth < 550) {
+    if (scrollModeQuery.matches) {
         changeDisplayMode('scroll');
     }
 }
@@ -273,5 +275,5 @@ export async function initializeSkills(translations) {
 export function setupSkillsUI() {
     setupDisplayMode();
     handleResponsiveDisplay();
-    window.addEventListener('resize', handleResponsiveDisplay);
+    scrollModeQuery.addEventListener('change', handleResponsiveDisplay);
 }


### PR DESCRIPTION
## Summary
- Cache marker width and progress bar rectangle to minimize layout thrashing in progress bars
- Precompute SVG matrices and viewport size for bender eyes animation to avoid repeated geometry reads
- Use `matchMedia` for responsive checks and defer initial eye rendering to improve performance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a630221e48330b593aa469501ca69