### PR TITLE
Bloqueia download de certificado sem link

### DIFF
--- a/js/certificates.js
+++ b/js/certificates.js
@@ -156,7 +156,7 @@ export async function initializeCertificates() {
                     </div>
                 </div>
                 <div class="card-buttons">
-                    ${certificado.status
+                    ${certificado.status && certificado.certificationUrl && certificado.certificationUrl.trim() !== ''
                         ? `<a target="_blank" href="${certificado.certificationUrl}" aria-label="Abrir o certificado">
                             <button class="fa-solid fa-download download-button tooltip" aria-label="Abrir o certificado">
                                 <span class="tooltip-text">Ver certificado</span>


### PR DESCRIPTION
## Summary
- Valida link do certificado antes de habilitar download, bloqueando quando estiver ausente ou o curso não estiver concluído

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a07158e9888330bee2d60382bf75a6