### PR TITLE
feat: add responsive slideshow images

### DIFF
--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -1,0 +1,46 @@
+{% if section.settings.desktop_image or section.settings.mobile_image %}
+  <div class="slideshow">
+    <picture>
+      {% if section.settings.mobile_image != blank %}
+        <source media="(max-width: 989px)" srcset="{{ section.settings.mobile_image | image_url: width: 989 }}">
+      {% endif %}
+      {% if section.settings.desktop_image != blank %}
+        <source media="(min-width: 990px)" srcset="{{ section.settings.desktop_image | image_url: width: 1500 }}">
+        <img src="{{ section.settings.desktop_image | image_url: width: 1500 }}"
+             width="{{ section.settings.desktop_image.width }}"
+             height="{{ section.settings.desktop_image.height }}"
+             alt="{{ section.settings.desktop_image.alt | escape }}"
+             loading="lazy">
+      {% else %}
+        <img src="{{ section.settings.mobile_image | image_url: width: 989 }}"
+             width="{{ section.settings.mobile_image.width }}"
+             height="{{ section.settings.mobile_image.height }}"
+             alt="{{ section.settings.mobile_image.alt | escape }}"
+             loading="lazy">
+      {% endif %}
+    </picture>
+  </div>
+{% endif %}
+
+{% schema %}
+{
+  "name": "Slideshow",
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "desktop_image",
+      "label": "Desktop image"
+    },
+    {
+      "type": "image_picker",
+      "id": "mobile_image",
+      "label": "Mobile image"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Slideshow"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- support separate desktop and mobile images in slideshow section
- simplify slideshow schema to single image with desktop/mobile variants

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24da66f2883309fcd77e68aea469a